### PR TITLE
Setting HTTP/1.1 in nginx config examples

### DIFF
--- a/Reverse Proxy Configurations/nginx/nginx.cluster.conf
+++ b/Reverse Proxy Configurations/nginx/nginx.cluster.conf
@@ -63,6 +63,7 @@ http {
               proxy_set_header X-Forwarded-Host $host;
               proxy_set_header X-Forwarded-Server $host;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_http_version 1.1;
               proxy_pass http://fusionauth/;
         }
     }

--- a/Reverse Proxy Configurations/nginx/nginx.dev.conf
+++ b/Reverse Proxy Configurations/nginx/nginx.dev.conf
@@ -8,6 +8,7 @@ server {
         location / {
                 proxy_set_header "X-Forwarded-Host" "example.com;
                 proxy_set_header "X-Forwarded-Port" "80";
+                proxy_http_version 1.1;
                 proxy_pass http://127.0.0.1:9011;
         }
 }

--- a/Reverse Proxy Configurations/nginx/nginx.nonrootpath.excerpt.conf
+++ b/Reverse Proxy Configurations/nginx/nginx.nonrootpath.excerpt.conf
@@ -30,6 +30,7 @@ http {
             proxy_set_header X-Forwarded-Server $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Accept-Encoding "";
+            proxy_http_version 1.1;
             sub_filter       'action="/'  'action="/fa/';
             sub_filter       'href="/'  'href="/fa/';
             sub_filter       'src="/images'  'src="/fa/images';
@@ -50,6 +51,7 @@ http {
             proxy_set_header X-Forwarded-Server $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Accept-Encoding "";
+            proxy_http_version 1.1;
             sub_filter       'action="/'  'action="/fa/';
             sub_filter       'href="/'  'href="/fa/';
             sub_filter       'src="/images'  'src="/fa/images';

--- a/Reverse Proxy Configurations/nginx/nginx.ssl.conf
+++ b/Reverse Proxy Configurations/nginx/nginx.ssl.conf
@@ -42,6 +42,7 @@ server {
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_read_timeout  90;
+    proxy_http_version  1.1;
 
     location / {
       proxy_pass http://localhost:9011;


### PR DESCRIPTION
Following [this post by Dan](https://fusionauth.io/community/forum/topic/2254/having-an-issue-with-nginx-in-front-of-fusionauth) to define HTTP/1.1 in nginx config files.

I don't know about the other services if they need something similar as I only use nginx, so maybe we should revisit them as well.